### PR TITLE
web: make work on gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "format": "prettier -c \"**/*.+(js|jsx|ts|tsx|json|css|md)\"",
     "format:fix": "prettier --write \"**/*.+(js|jsx|ts|tsx|json|css|md)\""
   },
+  "homepage": "./",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -20,15 +20,6 @@
       async
       src="https://www.googletagmanager.com/gtag/js?id=UA-112467444-2"
     ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "UA-112467444-2");
-    </script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,13 +7,24 @@ import { ClusterStatusButton } from "components/ClusterStatusButton";
 export function Navbar() {
   // TODO: use `collapsing` to animate collapsible navbar
   const [collapse, setCollapse] = React.useState(false);
+  // TODO(thlorenz): Total hack to fix static resources like this not working on gh-pages
+  const logo =
+    process.env.NODE_ENV === "production" ? (
+      <img
+        src="./amman-explorer/build/static/media/dark-explorer-logo.2d910a55.svg"
+        width="250"
+        alt="Solana Explorer"
+      />
+    ) : (
+      <img src={Logo} width="250" alt="Solana Explorer" />
+    );
 
   return (
     <nav className="navbar navbar-expand-md navbar-light">
       <div className="container">
         <Link to={clusterPath("/")}>
           <span>Amman</span>
-          <img src={Logo} width="250" alt="Solana Explorer" />
+          {logo}
         </Link>
 
         <button


### PR DESCRIPTION
Did the following to make things at least _work_ on gh-pages:

- web: remove google analytics
- web: fix homepage entry
- hack: fix solana logo for now (this is temporary)

Hacked this a bit as doing this properly may not be necessary if this is hosted somewhere in
the future.
